### PR TITLE
feature: sf6 style frame meter bar & dummy reversal trainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ out/
 **/bin/
 **/obj/
 **/publish/
+*.nut.h
+*.txt.h

--- a/src/Netcode/embed/menu.nut
+++ b/src/Netcode/embed/menu.nut
@@ -65,7 +65,381 @@ PracticeInitializeOrig <- practice.Initialize;
 practice.Initialize = function() {
 	::menu.pause_hack = true;
 	::overlay.clear();
+
+	// Disconnect and remove old oki sprites to prevent accumulation
+	if ("_oki_sprites" in ::menu) {
+		foreach (s in ::menu._oki_sprites) {
+			try { s.DisconnectRenderSlot(); } catch(e) {}
+			try { s.x = -9999; } catch(e) {}
+		}
+	}
+	::menu._oki_sprites <- [];
+
+	// Clean up previous oki items from item_list[3] so PracticeInitializeOrig
+	// sees the original list and doesn't accumulate duplicates across pauses.
+	local il = this.item_list[3];
+	for (local i = il.len() - 1; i >= 0; i--) {
+		if (il[i] == "oki_dir" || il[i] == "oki_btn" || il[i] == "oki_slot" || il[i] == "oki_wt" || il[i] == "oki_dly" || il[i] == "oki_trg") il.remove(i);
+	}
+
 	::menu.PracticeInitializeOrig.call(this);
+
+	// Always re-insert Oki items — PracticeInitializeOrig resets page[3].cursor
+	// and BeginAnime rebuilds anime.page[3], so we must rebuild every time.
+	if (!("oki_slot" in ::config.practice)) {
+		::config.practice.oki_slot <- 0;
+		if ("oki_dir" in ::config.practice) {
+			::config.practice.oki_s0_dir <- ::config.practice.oki_dir;
+			::config.practice.oki_s0_btn <- ::config.practice.oki_btn;
+		} else {
+			::config.practice.oki_s0_dir <- 5;
+			::config.practice.oki_s0_btn <- 0;
+		}
+		for (local s = 1; s < 5; s++) {
+			::config.practice["oki_s" + s + "_dir"] <- 5;
+			::config.practice["oki_s" + s + "_btn"] <- 8;
+		}
+	}
+	// Migrate: ensure weight/delay/trigger exist for all slots
+	for (local s = 0; s < 5; s++) {
+		local wk = "oki_s" + s + "_weight";
+		if (!(wk in ::config.practice)) ::config.practice[wk] <- 5;
+		local dk = "oki_s" + s + "_delay";
+		if (!(dk in ::config.practice)) ::config.practice[dk] <- 0;
+		local tk = "oki_s" + s + "_trigger";
+		if (!(tk in ::config.practice)) ::config.practice[tk] <- 0;
+	}
+
+	// 1. Insert into item_list[3]
+	// indices: 5=slot, 6=dir, 7=btn, 8=wt, 9=dly, 10=trg
+	il.insert(5, "oki_trg");
+	il.insert(5, "oki_dly");
+	il.insert(5, "oki_wt");
+	il.insert(5, "oki_btn");
+	il.insert(5, "oki_dir");
+	il.insert(5, "oki_slot");
+
+	// 2. Create item-level cursors — type=1 (UpdateH, responds to LR)
+	local cursor_slot = this.Cursor(1, 5, ::input_all);
+	local cursor_dir = this.Cursor(1, 9, ::input_all);
+	local cursor_btn = this.Cursor(1, 9, ::input_all);
+	local cursor_wt = this.Cursor(1, 10, ::input_all);
+	local cursor_dly = this.Cursor(1, 16, ::input_all);
+	local cursor_trg = this.Cursor(1, 2, ::input_all);
+	cursor_slot.enable_ok = false; cursor_slot.enable_cancel = false;
+	cursor_dir.enable_ok = false; cursor_dir.enable_cancel = false;
+	cursor_btn.enable_ok = false; cursor_btn.enable_cancel = false;
+	cursor_wt.enable_ok = false; cursor_wt.enable_cancel = false;
+	cursor_dly.enable_ok = false; cursor_dly.enable_cancel = false;
+	cursor_trg.enable_ok = false; cursor_trg.enable_cancel = false;
+	// Initialize cursors from current slot's config
+	local sl = ::config.practice.oki_slot;
+	cursor_slot.val = sl;
+	cursor_dir.val = ::config.practice["oki_s" + sl + "_dir"] - 1;
+	local sbtn = ::config.practice["oki_s" + sl + "_btn"];
+	if (sbtn < 0 || sbtn >= 9) sbtn = 0;
+	cursor_btn.val = sbtn;
+	local swt = ::config.practice["oki_s" + sl + "_weight"];
+	if (swt < 1 || swt > 10) swt = 5;
+	cursor_wt.val = swt - 1;
+	local sdly = ::config.practice["oki_s" + sl + "_delay"];
+	if (sdly < 0 || sdly > 15) sdly = 0;
+	cursor_dly.val = sdly;
+	local strg = ::config.practice["oki_s" + sl + "_trigger"];
+	if (strg < 0 || strg > 1) strg = 0;
+	cursor_trg.val = strg;
+	this.page[3].cursor["oki_slot"] <- cursor_slot;
+	this.page[3].cursor["oki_dir"] <- cursor_dir;
+	this.page[3].cursor["oki_btn"] <- cursor_btn;
+	this.page[3].cursor["oki_wt"] <- cursor_wt;
+	this.page[3].cursor["oki_dly"] <- cursor_dly;
+	this.page[3].cursor["oki_trg"] <- cursor_trg;
+	::print("[oki-menu] init: slot=" + sl + " dir=" + cursor_dir.val + " btn=" + cursor_btn.val + " wt=" + cursor_wt.val + " dly=" + cursor_dly.val + " trg=" + cursor_trg.val + "\n");
+
+	// 3. Create label sprites + select_obj for the three new items
+	local t = ::menu.common.item_y - 32 - 8;  // 160
+	local spc = 32;
+	local lx = ::menu.common.item_x - 240;   // 400
+	local pg = this.anime.page[3];
+
+	// --- Helper: multi-sprite select_obj (native-style rendering) ---
+	local function MakeSelect(options, x, y, mat, curs) {
+		local item = [];
+		foreach (opt in options) {
+			local s = ::font.CreateSystemString(opt);
+			s.ConnectRenderSlot(::graphics.slot.overlay, 0);
+			s.x = x; s.y = y; s.visible = false;
+			::menu._oki_sprites.append(s);
+			item.append(s);
+		}
+		item[curs.val].visible = true;
+		local cur = curs.val;
+		return {
+			item   = item,
+			cursor = curs,
+			mat_world = mat,
+			current  = cur,
+			active   = false,
+			Update   = function() {
+				foreach (v in this.item) v.SetWorldTransform(this.mat_world);
+				if (this.cursor.val != this.current) {
+					this.item[this.current].visible = false;
+					this.current = this.cursor.val;
+					this.item[this.current].visible = true;
+				}
+			},
+			Show = function() {
+				if (this.current < this.item.len())
+					this.item[this.current].visible = true;
+			},
+			Hide = function() {
+				foreach (v in this.item) v.visible = false;
+			}
+		};
+	}
+
+	// Reversal Slot # (j=5, y=320)
+	local ts = ::font.CreateSystemString("Reversal Slot #");
+	ts.ConnectRenderSlot(::graphics.slot.overlay, 0);
+	ts.x = lx; ts.y = t + 5 * spc;
+	::menu._oki_sprites.append(ts);
+	local islot = { text = ts, select_obj = null };
+	islot.select_obj = MakeSelect(
+		["1","2","3","4","5"],
+		ts.x + 320, ts.y, pg.mat_world, cursor_slot
+	);
+
+	// Direction (j=6, y=352)
+	local td = ::font.CreateSystemString("  Direction");
+	td.ConnectRenderSlot(::graphics.slot.overlay, 0);
+	td.x = lx; td.y = t + 6 * spc;
+	::menu._oki_sprites.append(td);
+	local idir = { text = td, select_obj = null };
+	idir.select_obj = MakeSelect(
+		["1","2","3","4","5","6","7","8","9"],
+		td.x + 320, td.y, pg.mat_world, cursor_dir
+	);
+
+	// Action (j=7, y=384)
+	local tb = ::font.CreateSystemString("  Action");
+	tb.ConnectRenderSlot(::graphics.slot.overlay, 0);
+	tb.x = lx; tb.y = t + 7 * spc;
+	::menu._oki_sprites.append(tb);
+	local iact = { text = tb, select_obj = null };
+	iact.select_obj = MakeSelect(
+		["A","B","C","D","P","AB","BC","CP","Off"],
+		tb.x + 320, tb.y, pg.mat_world, cursor_btn
+	);
+
+	// Weight (j=8, y=416)
+	local tw = ::font.CreateSystemString("  Weight");
+	tw.ConnectRenderSlot(::graphics.slot.overlay, 0);
+	tw.x = lx; tw.y = t + 8 * spc;
+	::menu._oki_sprites.append(tw);
+	local iwt = { text = tw, select_obj = null };
+	iwt.select_obj = MakeSelect(
+		["1","2","3","4","5","6","7","8","9","10"],
+		tw.x + 320, tw.y, pg.mat_world, cursor_wt
+	);
+
+	// Delay (j=9, y=448)
+	local tdl = ::font.CreateSystemString("  Delay");
+	tdl.ConnectRenderSlot(::graphics.slot.overlay, 0);
+	tdl.x = lx; tdl.y = t + 9 * spc;
+	::menu._oki_sprites.append(tdl);
+	local idly = { text = tdl, select_obj = null };
+	idly.select_obj = MakeSelect(
+		["0f","1f","2f","3f","4f","5f","6f","7f","8f","9f","10f","11f","12f","13f","14f","15f"],
+		tdl.x + 320, tdl.y, pg.mat_world, cursor_dly
+	);
+
+	// Trigger (j=10, y=480)
+	local ttr = ::font.CreateSystemString("  Trigger");
+	ttr.ConnectRenderSlot(::graphics.slot.overlay, 0);
+	ttr.x = lx; ttr.y = t + 10 * spc;
+	::menu._oki_sprites.append(ttr);
+	local itrg = { text = ttr, select_obj = null };
+	itrg.select_obj = MakeSelect(
+		["Hit","Block"],
+		ttr.x + 320, ttr.y, pg.mat_world, cursor_trg
+	);
+
+	// 4. Insert real items into pg.item (anime system handles rendering + highlighting)
+	pg.item.insert(5, islot);
+	pg.item.insert(6, idir);
+	pg.item.insert(7, iact);
+	pg.item.insert(8, iwt);
+	pg.item.insert(9, idly);
+	pg.item.insert(10, itrg);
+
+	// 5. Shift common items (now at pg.item indices 11+, were 5+) down 192px
+	for (local j = 11; j < pg.item.len(); j++) {
+		if (pg.item[j] && pg.item[j].text) {
+			pg.item[j].text.y += 192;
+			if (pg.item[j].select_obj) {
+				foreach (s in pg.item[j].select_obj.item) s.y += 192;
+			}
+		}
+	}
+
+	// 6. Update page cursor — rebuild skip from modified item_list
+	local ci = this.cursor_item_list[3];
+	ci.item_num = il.len();
+	local sk = []; foreach (v in il) sk.append(v ? 0 : 1);
+	ci.SetSkip(sk);
+
+	// 7. If currently on page 3, resync
+	if (this.cursor_page.val == 3) {
+		this.item = il;
+		this.cursor_item = ci;
+	}
+
+	// --- Patch ex_guard_mode: extend 2→3 options (add Just Guard) ---
+	// Game engine supports ex_guard_mode=2 (Just Guard) but the cursor only
+	// has item_num=2, causing "the index '2' does not exist" crash.
+	{
+		// Clamp config before patching cursor
+		if (typeof ::config.practice.ex_guard_mode != "integer"
+			|| ::config.practice.ex_guard_mode < 0
+			|| ::config.practice.ex_guard_mode > 2)
+			::config.practice.ex_guard_mode = 0;
+
+		local eg_cursor = this.page[2].cursor["ex_guard_mode"];
+		eg_cursor.item_num = 3;
+		eg_cursor.val = ::config.practice.ex_guard_mode;
+
+		// Find ex_guard_mode in anime.page[2].item (index matches item_list[2])
+		local eg_idx = -1;
+		foreach (idx, name in this.item_list[2]) {
+			if (name == "ex_guard_mode") { eg_idx = idx; break; }
+		}
+		if (eg_idx >= 0) {
+			local pg2 = this.anime.page[2];
+			local eg_item = pg2.item[eg_idx];
+			if (eg_item && eg_item.select_obj) {
+				// Disconnect old select_obj sprites from overlay
+				try { foreach (v in eg_item.select_obj.item) { v.visible = false; v.DisconnectRenderSlot(); } } catch(e) {}
+				// Replace with 3-option select
+				eg_item.select_obj = MakeSelect(
+					["Off", "Barrier Guard", "Just Guard"],
+					eg_item.text.x + 320, eg_item.text.y,
+					pg2.mat_world, eg_cursor
+				);
+			}
+		}
+	}
+
+	// Patch UpdateMain: handle LR on Oki items, sync to config, prevent page switch
+	local orig_update = this.UpdateMain;
+	this.UpdateMain = function() {
+		local cp_saved = this.cursor_page.val;
+		local ci_saved = this.cursor_item.val;
+		local prev_slot = ::config.practice.oki_slot;
+
+		// --- Focus-toggle for Oki items (matching No/Yes pattern) ---
+		// Unfocused: LR switches pages, UD moves between items.
+		// Press Z → lock/focus the item → LR changes values, page blocked.
+		// Press Z again or move away → unlock/unfocus.
+		local on_oki = (cp_saved == 3 && ci_saved >= 5 && ci_saved <= 10);
+
+		// Edge-detect Z via 0→non-zero transition on input_all.b0
+		local b0_now = 0;
+		try { b0_now = ::input_all.b0; } catch(e) {}
+		if (!("_oki_b0_prev" in ::menu)) ::menu._oki_b0_prev <- 0;
+		local z_edge = (b0_now != 0 && ::menu._oki_b0_prev == 0);
+		::menu._oki_b0_prev = b0_now;
+
+		if (!("_oki_focused" in ::menu)) ::menu._oki_focused <- false;
+
+		// Auto-unfocus when cursor moves away from Oki items
+		if (!on_oki) ::menu._oki_focused = false;
+
+		// Z toggles focus on Oki items
+		if (on_oki && z_edge) ::menu._oki_focused = !::menu._oki_focused;
+
+		// When focused: process LR to change values
+		if (on_oki && ::menu._oki_focused) {
+			if ("oki_slot" in this.page[3].cursor) {
+				local curs;
+				if (ci_saved == 5) curs = this.page[3].cursor["oki_slot"];
+				else if (ci_saved == 6) curs = this.page[3].cursor["oki_dir"];
+				else if (ci_saved == 7) curs = this.page[3].cursor["oki_btn"];
+				else if (ci_saved == 8) curs = this.page[3].cursor["oki_wt"];
+				else if (ci_saved == 9) curs = this.page[3].cursor["oki_dly"];
+				else curs = this.page[3].cursor["oki_trg"];
+				curs.Update();
+
+				// Slot changed: sync all cursors to new slot's values
+				if (ci_saved == 5) {
+					local new_sl = curs.val;
+					if (new_sl != prev_slot) {
+						::config.practice.oki_slot = new_sl;
+						this.page[3].cursor["oki_dir"].val = ::config.practice["oki_s" + new_sl + "_dir"] - 1;
+						this.page[3].cursor["oki_btn"].val = ::config.practice["oki_s" + new_sl + "_btn"];
+						local nwt = ::config.practice["oki_s" + new_sl + "_weight"];
+						this.page[3].cursor["oki_wt"].val = (nwt < 1 || nwt > 10) ? 4 : nwt - 1;
+						this.page[3].cursor["oki_dly"].val = ::config.practice["oki_s" + new_sl + "_delay"];
+						local ntrg = ::config.practice["oki_s" + new_sl + "_trigger"];
+						this.page[3].cursor["oki_trg"].val = (ntrg < 0 || ntrg > 1) ? 0 : ntrg;
+					}
+				}
+			}
+		}
+
+		// Save cursor values before orig_update (don't delete entries —
+		// deleting causes crashes if orig_update triggers BeginAnime).
+		// orig_update may corrupt our cursor values; restore after.
+		local _oki_saved = null;
+		if ("oki_slot" in this.page[3].cursor) {
+			_oki_saved = {
+				slot = this.page[3].cursor["oki_slot"].val,
+				dir  = this.page[3].cursor["oki_dir"].val,
+				btn  = this.page[3].cursor["oki_btn"].val,
+				wt   = this.page[3].cursor["oki_wt"].val,
+				dly  = this.page[3].cursor["oki_dly"].val,
+				trg  = this.page[3].cursor["oki_trg"].val
+			};
+		}
+
+		orig_update.call(this);
+
+		// Restore cursor values that orig_update may have changed
+		if (_oki_saved && "oki_slot" in this.page[3].cursor) {
+			this.page[3].cursor["oki_slot"].val = _oki_saved.slot;
+			this.page[3].cursor["oki_dir"].val  = _oki_saved.dir;
+			this.page[3].cursor["oki_btn"].val  = _oki_saved.btn;
+			this.page[3].cursor["oki_wt"].val   = _oki_saved.wt;
+			this.page[3].cursor["oki_dly"].val  = _oki_saved.dly;
+			this.page[3].cursor["oki_trg"].val  = _oki_saved.trg;
+		}
+
+		// Anime system handles all rendering: text highlighting, cursor indicator,
+		// page visibility. No manual overlay management needed.
+
+		// When focused on Oki item: block page switch caused by LR
+		if (on_oki && ::menu._oki_focused) {
+			if (this.cursor_page.val != cp_saved) {
+				this.cursor_page.val = cp_saved;
+				this.cursor_page.diff = 0;
+				this.item = this.item_list[cp_saved];
+				this.cursor_item = this.cursor_item_list[cp_saved];
+				this.cursor_item.val = ci_saved;
+			}
+		}
+
+		// Sync config: write Dir/Act/Wt/Dly to current slot
+		try {
+			if (this.cursor_page.val == 3 && "oki_slot" in this.page[3].cursor) {
+				local sl = ::config.practice.oki_slot;
+				::config.practice["oki_s" + sl + "_dir"] = this.page[3].cursor["oki_dir"].val + 1;
+				::config.practice["oki_s" + sl + "_btn"] = this.page[3].cursor["oki_btn"].val;
+				::config.practice["oki_s" + sl + "_weight"] = this.page[3].cursor["oki_wt"].val + 1;
+				::config.practice["oki_s" + sl + "_delay"] = this.page[3].cursor["oki_dly"].val;
+				::config.practice["oki_s" + sl + "_trigger"] = this.page[3].cursor["oki_trg"].val;
+			}
+		} catch (e) {}
+	};
+	this.Update = this.UpdateMain;
 }
 
 foreach (key,str in {
@@ -177,4 +551,28 @@ foreach( v in scene )
 		v.EndAnime <- EndAnime;
 		v.EndAnimeDelayed <- EndAnimeDelayed;
 	}
+}
+
+// Patch practice scene cleanup: disconnect oki sprites when leaving training mode
+if ("EndAnime" in practice) {
+	local _orig_practice_end_anime = practice.EndAnime;
+	practice.EndAnime = function() {
+		if ("_oki_sprites" in ::menu) {
+			foreach (s in ::menu._oki_sprites) {
+				try { s.DisconnectRenderSlot(); } catch(e) {}
+			}
+		}
+		_orig_practice_end_anime.call(this);
+	};
+}
+if ("EndAct" in practice) {
+	local _orig_practice_end_act = practice.EndAct;
+	practice.EndAct = function() {
+		if ("_oki_sprites" in ::menu) {
+			foreach (s in ::menu._oki_sprites) {
+				try { s.DisconnectRenderSlot(); } catch(e) {}
+			}
+		}
+		_orig_practice_end_act.call(this);
+	};
 }

--- a/src/Netcode/embed/plugin/core/manager.nut
+++ b/src/Netcode/embed/plugin/core/manager.nut
@@ -134,8 +134,10 @@ Patch("data/system/component/menu_common.nut",function() {
 
 // Built-in plugins, feel free to comment out if not wanted
 LoadNativePlugin("squiroll/plugin/frame_data.nut","frame_data");
+LoadNativePlugin("squiroll/plugin/frame_bar.nut","frame_bar");
 LoadNativePlugin("squiroll/plugin/input_display.nut","input_display");
 LoadNativePlugin("squiroll/plugin/framerate_control.nut","framerate_control");
+LoadNativePlugin("squiroll/plugin/oki_dummy.nut","oki_dummy");
 LoadNativePlugin("squiroll/plugin/ping_display.nut","ping_display");
 
 ::mkdir("plugin");

--- a/src/Netcode/embed/plugin/frame_bar.nut
+++ b/src/Netcode/embed/plugin/frame_bar.nut
@@ -1,0 +1,710 @@
+// Frame Bar - SF6-style visual frame meter bar (standalone module)
+//
+// Dual-team tracking with sprite-based timeline rendering:
+//   - Phase colors: green (startup), red (active), blue (recovery), yellow (stun)
+//   - Cancel window (left quarter) and invincibility (right quarter) overlays
+//   - Segment count labels for phases > 3f
+//   - Frame advantage calculation between attacker and defender
+//   - Timeline alignment so both bars share the same time axis
+//
+// This module is independent of frame_data.nut (text display).
+// frame_data.nut keeps its own single-team tracking and config menu.
+
+config = {
+    enabled = true
+    x = 280
+    y = 555
+    sx = 0.75
+    sy = 0.75
+    width = 720
+};
+
+// Patches
+::plugin.Patch("data/script/actor.nut",function() {
+    local createplayer = CreatePlayer;
+    function CreatePlayer(...) {
+    	vargv.insert(0,this);
+    	local t = createplayer.acall(vargv);
+
+    	t.player_class = class extends t.player_class {
+    		_tid = -1;
+    		function SetMotion(motion, take) {
+    			base.SetMotion(motion,take);
+    			if (!("_tid" in this)) return;
+    			local task = ::battle.modifiers.frame_bar.task;
+    			if (!task || !task.current_data) return;
+
+    			// Resolve team index on first call
+    			if (_tid < 0) {
+    				if (task.teams[0] && task.teams[0] == team) _tid = 0;
+    				else if (task.teams[1] && task.teams[1] == team) _tid = 1;
+    			}
+    			if (_tid < 0) return;
+
+    			local cd = task.current_data[_tid];
+    			if (cd && cd.motion != motion && cd.take >= keyTake) {
+    				if (motion >= 1000) {
+    					// Cancel (attack->attack) or gap (idle->attack)?
+    					if (cd.frame_count > 0 && cd.motion >= 1000) {
+    						task.ContinueMove(_tid);
+    					} else {
+    						task.IsNewMove(_tid);
+    					}
+    				} else {
+    					cd.motion = motion;
+    				}
+    			}
+    		}
+    	};
+
+    	return t;
+    }
+});
+
+// Base class for display elements
+class display_module {
+    text = null;
+    max_w = null;
+    constructor() {
+        max_w = 1010;
+        text = ::UI.Core.Text();
+        text.sy = 0.75;
+        text.red = text.green = text.blue = text.alpha = 1;
+        text.ConnectRenderSlot(::graphics.slot.info,1);
+    }
+    function Render(data) {}
+    function Clear() {text.Set("");}
+}
+
+class modifier extends modifier {
+    // Sprite-based frame bar with phase colors, overlays, and frame advantage
+    framebar = class extends display_module {
+        pool = null;
+        pool_size = 60;
+        tex = null;
+        label = null;
+        team_idx = 0;
+        label_below = false;
+        count_labels = null;
+        adv_label = null;
+        bg_bar = null;
+        cancel_pool = null;
+        inv_pool = null;
+
+        PIP_W = 12.0;
+        BAR_H = 22.0;
+        GAP = 1.0;
+        TEX_SIZE = 16.0;
+
+        constructor(_team_idx = 0, _label_below = false) {
+            team_idx = _team_idx;
+            label_below = _label_below;
+
+            pool = [];
+            tex = ::manbow.Texture();
+            tex.Load("data/actor/status/texture/gauge.png");
+
+            label = ::UI.Core.Text();
+            label.sy = 0.75;
+            label.red = label.green = label.blue = label.alpha = 1;
+            label.ConnectRenderSlot(::graphics.slot.info, 2);
+
+            adv_label = ::UI.Core.Text();
+            adv_label.sy = 0.75;
+            adv_label.ConnectRenderSlot(::graphics.slot.info, 2);
+
+            bg_bar = ::manbow.Sprite();
+            bg_bar.Initialize(tex, 264, 360, 16, 16);
+            bg_bar.filter = 1;
+            bg_bar.ConnectRenderSlot(::graphics.slot.info, 0);
+            bg_bar.alpha = 0;
+
+            for (local i = 0; i < pool_size; i++) {
+                local s = ::manbow.Sprite();
+                s.Initialize(tex, 264, 360, 16, 16);
+                s.filter = 1;
+                s.ConnectRenderSlot(::graphics.slot.info, 1);
+                s.alpha = 0;
+                pool.append(s);
+            }
+
+            count_labels = [];
+            for (local i = 0; i < 10; i++) {
+                local t = ::UI.Core.Text();
+                t.sy = 0.5;
+                t.sx = 0.5;
+                t.red = 1; t.green = 1; t.blue = 1; t.alpha = 0.9;
+                t.ConnectRenderSlot(::graphics.slot.info, 2);
+                count_labels.append(t);
+            }
+
+            cancel_pool = [];
+            for (local i = 0; i < pool_size; i++) {
+                local s = ::manbow.Sprite();
+                s.Initialize(tex, 264, 360, 16, 16);
+                s.filter = 1;
+                s.ConnectRenderSlot(::graphics.slot.info, 1);
+                s.alpha = 0;
+                cancel_pool.append(s);
+            }
+
+            inv_pool = [];
+            for (local i = 0; i < pool_size; i++) {
+                local s = ::manbow.Sprite();
+                s.Initialize(tex, 264, 360, 16, 16);
+                s.filter = 1;
+                s.ConnectRenderSlot(::graphics.slot.info, 1);
+                s.alpha = 0;
+                inv_pool.append(s);
+            }
+        }
+
+        function Render(data, adv = null) {
+            local cfg = ::plugin.cfg.frame_bar;
+            local bar_x = cfg.data.x.tofloat();
+            local base_y = cfg.data.y.tofloat();
+
+            // Layout: 1P-label -> 1P-bar -> gap -> 2P-bar -> 2P-label
+            local bar_y;
+            if (team_idx == 0) {
+                bar_y = base_y + 32;
+            } else {
+                bar_y = base_y + 32 + 22 + 4;
+            }
+
+            // Black background bar (border effect)
+            bg_bar.x = bar_x;
+            bg_bar.y = bar_y;
+            bg_bar.sx = (pool_size * PIP_W) / TEX_SIZE;
+            bg_bar.sy = BAR_H / TEX_SIZE;
+            bg_bar.red = 0; bg_bar.green = 0; bg_bar.blue = 0;
+            bg_bar.alpha = 0.9;
+
+            local pw = (PIP_W - GAP) / TEX_SIZE;
+            local ph = (BAR_H - 2) / TEX_SIZE;
+            local pip_y = bar_y + 1;
+            local prefix = team_idx == 0 ? "1P" : "2P";
+
+            // No data: show empty grid with label only
+            if (!data || data.frame_count <= 0) {
+                for (local i = 0; i < pool_size; i++) {
+                    local s = pool[i];
+                    s.x = bar_x + i * PIP_W + GAP * 0.5;
+                    s.y = pip_y;
+                    s.sx = pw;
+                    s.sy = ph;
+                    s.red = 0.35; s.green = 0.35; s.blue = 0.35;
+                    s.alpha = 0.5;
+                }
+                label.Set(prefix);
+                label.x = bar_x;
+                label.sx = 0.6;
+                label.y = label_below ? bar_y + BAR_H + 1 : bar_y - 32;
+                adv_label.Set("");
+                foreach(t in count_labels) t.Set("");
+                foreach(cs in cancel_pool) cs.alpha = 0;
+                foreach(cs in inv_pool) cs.alpha = 0;
+                return;
+            }
+
+            local fc = data.pip_colors;
+            local offset = data.timeline_offset;
+            // Visual end = offset + number of actual pips
+            local visual_end = offset + fc.len();
+
+            // Draw with timeline offset
+            if (visual_end <= 60) {
+                // Blank pips for offset (time alignment)
+                for (local i = 0; i < offset && i < pool_size; i++) {
+                    local s = pool[i];
+                    s.x = bar_x + i * PIP_W + GAP * 0.5;
+                    s.y = pip_y;
+                    s.sx = pw; s.sy = ph;
+                    s.red = 0.35; s.green = 0.35; s.blue = 0.35;
+                    s.alpha = 0.4;
+                }
+                // Actual pips
+                for (local i = 0; i < fc.len() && (offset + i) < pool_size; i++) {
+                    local s = pool[offset + i];
+                    s.x = bar_x + (offset + i) * PIP_W + GAP * 0.5;
+                    s.y = pip_y;
+                    s.sx = pw; s.sy = ph;
+                    s.red = fc[i][0]; s.green = fc[i][1]; s.blue = fc[i][2];
+                    s.alpha = 0.85;
+                }
+                // Empty grid after all pips
+                for (local i = visual_end; i < pool_size; i++) {
+                    local s = pool[i];
+                    s.x = bar_x + i * PIP_W + GAP * 0.5;
+                    s.y = pip_y;
+                    s.sx = pw; s.sy = ph;
+                    s.red = 0.35; s.green = 0.35; s.blue = 0.35;
+                    s.alpha = 0.5;
+                }
+            } else {
+                // Overflow with offset: ghost + bright
+                local current_start = ((visual_end - 1) / 60).tointeger() * 60;
+                local ghost_start = current_start - 60;
+                if (ghost_start < 0) ghost_start = 0;
+
+                // Ghost: dimmed
+                for (local vi = ghost_start; vi < current_start && vi < visual_end; vi++) {
+                    local pip = vi - ghost_start;
+                    if (pip >= 60) break;
+                    local s = pool[pip];
+                    s.x = bar_x + pip * PIP_W + GAP * 0.5;
+                    s.y = pip_y;
+                    s.sx = pw; s.sy = ph;
+                    if (vi < offset) {
+                        s.red = 0.12; s.green = 0.12; s.blue = 0.12;
+                        s.alpha = 0.08;
+                    } else {
+                        local ci = vi - offset;
+                        if (ci < fc.len()) {
+                            s.red = fc[ci][0] * 0.45;
+                            s.green = fc[ci][1] * 0.45;
+                            s.blue = fc[ci][2] * 0.45;
+                            s.alpha = 0.6;
+                        }
+                    }
+                }
+
+                // Current cycle: bright
+                for (local vi = current_start; vi < visual_end; vi++) {
+                    local pip = vi - current_start;
+                    if (pip >= 60) break;
+                    local s = pool[pip];
+                    s.x = bar_x + pip * PIP_W + GAP * 0.5;
+                    s.y = pip_y;
+                    s.sx = pw; s.sy = ph;
+                    if (vi < offset) {
+                        s.red = 0.12; s.green = 0.12; s.blue = 0.12;
+                        s.alpha = 0.15;
+                    } else {
+                        local ci = vi - offset;
+                        if (ci < fc.len()) {
+                            s.red = fc[ci][0]; s.green = fc[ci][1]; s.blue = fc[ci][2];
+                            s.alpha = 0.85;
+                        }
+                    }
+                }
+            }
+
+            // Cancel + Invincibility overlay (top half, split left/right)
+            local ph_half = (BAR_H - 2) / 2.0 / TEX_SIZE;
+            local pw_q = (PIP_W - GAP) / 2.0 / TEX_SIZE;
+            local half_w = (PIP_W - GAP) / 2.0;
+            local c_start = 0;
+            local c_end = visual_end;
+            if (visual_end > pool_size) {
+                c_start = ((visual_end - 1) / pool_size).tointeger() * pool_size;
+            }
+            for (local i = 0; i < pool_size; i++) {
+                local vi = c_start + i;
+                local cs = cancel_pool[i];
+                local is = inv_pool[i];
+                cs.alpha = 0;
+                is.alpha = 0;
+                if (vi >= c_end || vi < offset) continue;
+                local ci = vi - offset;
+                if (ci >= fc.len() || ci >= data.flag_states.len()) continue;
+                local fs = data.flag_states[ci];
+                local pip_x = bar_x + i * PIP_W + GAP * 0.5;
+
+                // Left quarter: cancel type
+                local cancel_flag = fs & 0x4420;
+                if (cancel_flag) {
+                    cs.x = pip_x;
+                    cs.y = pip_y;
+                    cs.sx = pw_q;
+                    cs.sy = ph_half;
+                    local nt = 0;
+                    if (cancel_flag & 0x20) nt++;
+                    if (cancel_flag & 0x400) nt++;
+                    if (cancel_flag & 0x4000) nt++;
+                    if (nt >= 2) { cs.red = 1.0; cs.green = 1.0; cs.blue = 1.0; }
+                    else if (cancel_flag & 0x20) { cs.red = 0.75; cs.green = 0.3; cs.blue = 1.0; }
+                    else if (cancel_flag & 0x400) { cs.red = 0.2; cs.green = 0.85; cs.blue = 0.9; }
+                    else if (cancel_flag & 0x4000) { cs.red = 1.0; cs.green = 0.55; cs.blue = 0.1; }
+                    cs.alpha = 0.9;
+                }
+
+                // Right quarter: invincibility type
+                local inv_flag = fs & 0x1B000;
+                if (inv_flag) {
+                    is.x = pip_x + half_w;
+                    is.y = pip_y;
+                    is.sx = pw_q;
+                    is.sy = ph_half;
+                    local nt = 0;
+                    if (inv_flag & 0x1000) nt++;
+                    if (inv_flag & 0x2000) nt++;
+                    if (inv_flag & 0x8000) nt++;
+                    if (inv_flag & 0x10000) nt++;
+                    if (nt >= 2) { is.red = 1.0; is.green = 1.0; is.blue = 1.0; }
+                    else if (inv_flag & 0x8000) { is.red = 1.0; is.green = 0.4; is.blue = 0.6; }
+                    else if (inv_flag & 0x10000) { is.red = 0.5; is.green = 1.0; is.blue = 0.3; }
+                    else if (inv_flag & 0x2000) { is.red = 1.0; is.green = 0.85; is.blue = 0.3; }
+                    else if (inv_flag & 0x1000) { is.red = 0.75; is.green = 0.75; is.blue = 0.85; }
+                    is.alpha = 0.9;
+                }
+            }
+
+            // Segment count labels (>3f per phase)
+            local label_idx = 0;
+            local vis_start = 0;
+            local vis_end = visual_end;
+            if (visual_end > pool_size) {
+                vis_start = ((visual_end - 1) / pool_size).tointeger() * pool_size;
+            }
+            local seg_color = null;
+            local seg_len = 0;
+            for (local vi = vis_start; vi < vis_end; vi++) {
+                local color = null;
+                if (vi >= offset) {
+                    local ci = vi - offset;
+                    if (ci < fc.len()) color = fc[ci];
+                }
+                local same = (color && seg_color &&
+                    color[0] == seg_color[0] &&
+                    color[1] == seg_color[1] &&
+                    color[2] == seg_color[2]);
+                if (same) {
+                    seg_len++;
+                } else {
+                    if (seg_len > 3 && seg_color && label_idx < count_labels.len()) {
+                        local pool_pos = (vi - 1) - vis_start;
+                        if (pool_pos >= 0 && pool_pos < pool_size) {
+                            local t = count_labels[label_idx];
+                            t.Set(format("%d", seg_len));
+                            t.sx = 0.5;
+                            t.x = bar_x + pool_pos * PIP_W + PIP_W / 2 - (t.width * t.sx) / 2;
+                            t.y = pip_y + (BAR_H - 2) / 2 - 5;
+                            label_idx++;
+                        }
+                    }
+                    seg_color = color;
+                    seg_len = color ? 1 : 0;
+                }
+            }
+            // Handle last segment
+            if (seg_len > 3 && seg_color && label_idx < count_labels.len()) {
+                local pool_pos = (vis_end - 1) - vis_start;
+                if (pool_pos >= 0 && pool_pos < pool_size) {
+                    local t = count_labels[label_idx];
+                    t.Set(format("%d", seg_len));
+                    t.sx = 0.5;
+                    t.x = bar_x + pool_pos * PIP_W + PIP_W / 2 - (t.width * t.sx) / 2;
+                    t.y = pip_y + (BAR_H - 2) / 2 - 5;
+                    label_idx++;
+                }
+            }
+            for (local i = label_idx; i < count_labels.len(); i++) {
+                count_labels[i].Set("");
+            }
+
+            // Summary text
+            local startup_f = 0;
+            foreach(idx, val in data.frames[0]) {
+                if (!(idx & 1) && val > 0) startup_f += val;
+            }
+            local active_f = 0;
+            foreach(idx, val in data.frames[1]) {
+                if (!(idx & 1) && val > 0) active_f += val;
+            }
+            local recovery_f = 0;
+            foreach(idx, val in data.frames[2]) {
+                if (!(idx & 1) && val > 0) recovery_f += val;
+            }
+            local stun_f = data.stun_count;
+            label.Set(format("%s S:%d A:%d R:%d Stun:%d",
+                prefix, startup_f, active_f, recovery_f, stun_f));
+            label.x = bar_x;
+            label.sx = 0.6;
+            label.y = label_below ? bar_y + BAR_H + 1 - 6 : bar_y - 32;
+            label.red = 1; label.green = 1; label.blue = 1;
+
+            if (adv != null) {
+                local display_adv = team_idx == 1 ? -adv : adv;
+                local sign = display_adv >= 0 ? "+" : "";
+                adv_label.Set(format(" | %s%d", sign, display_adv));
+                adv_label.sx = 0.6;
+                adv_label.y = label.y;
+                adv_label.x = label.x + label.width * label.sx;
+                if (display_adv > 0) {
+                    adv_label.red = 0.3; adv_label.green = 0.5; adv_label.blue = 1.0;
+                } else if (display_adv < 0) {
+                    adv_label.red = 1.0; adv_label.green = 0.2; adv_label.blue = 0.2;
+                } else {
+                    adv_label.red = 1; adv_label.green = 1; adv_label.blue = 1;
+                }
+                adv_label.alpha = 1;
+            } else {
+                adv_label.Set("");
+            }
+        }
+
+        function Clear() {
+            label.Set("");
+            adv_label.Set("");
+            bg_bar.alpha = 0;
+            foreach(s in pool) s.alpha = 0;
+            foreach(cs in cancel_pool) cs.alpha = 0;
+            foreach(cs in inv_pool) cs.alpha = 0;
+            foreach(t in count_labels) t.Set("");
+        }
+    };
+
+    // Per-team state (index 0 = 1P, index 1 = 2P)
+    teams = null;
+    current_data = null;
+    actives = null;
+    tracked_last_frame = null;
+
+    parts = null;
+
+    constructor() {
+        teams = [null, null];
+        current_data = [null, null];
+        actives = [false, false];
+        tracked_last_frame = [false, false];
+
+        parts = {};
+        parts.framebar1 <- framebar(0, false);  // 1P: label above
+        parts.framebar2 <- framebar(1, true);   // 2P: label below
+    }
+
+    function Release() {foreach(key,_ in parts)delete parts[key];}
+
+    function Tick(tid, data) {
+        local current = teams[tid].current;
+
+        data.frame_count++;
+        data.flag_state = current.flagState;
+        data.flag_attack = current.flagAttack;
+        data.flag_states.append(current.flagState);
+        if(::setting.frame_data.GetMetadata(current)[0])data.metadata = ::setting.frame_data.GetMetadata(current);
+
+        // Phase detection with had_active state machine
+        local phase = 0; // 0=startup, 1=active, 2=recovery
+        if (!actives[tid]) actives[tid] = ::setting.frame_data.IsFrameActive(current);
+        if (actives[tid]) {
+            phase = 1;
+            data.had_active = true;
+        } else if (data.had_active) {
+            phase = 2;
+        }
+
+        // Record per-frame color
+        local phase_colors = [
+            [0.2, 0.75, 0.2],  // 0: startup - green
+            [0.85, 0.15, 0.15], // 1: active - red
+            [0.2, 0.4, 0.85],  // 2: recovery - blue
+        ];
+        data.pip_colors.append(phase_colors[phase]);
+
+        // Also update frames array (for summary labels)
+        local top = data.frames[phase].len() - 1;
+        data.frames[phase][top]++;
+
+        // Armor handling
+        if (current.armor) {
+            if (!data.armor.len() ||
+                data.armor.top()[0] != current.armor ||
+                data.armor.top()[2] != data.frame_count - 1
+            ){
+                data.armor.append([current.armor,data.frame_count,data.frame_count]);
+            }else {
+                data.armor.top()[2] = data.frame_count;
+            }
+        }
+
+        // Cancel handling
+        if (data.flag_state) {
+            local cancels = data.flag_state & 0x4420;
+            if (!data.cancels.len() ||
+                data.cancels.top()[0] != cancels ||
+                data.cancels.top()[2] != data.frame_count - 1
+            ){
+                data.cancels.append([cancels,data.frame_count,data.frame_count]);
+            }else {
+                data.cancels.top()[2] = data.frame_count;
+            }
+        }
+    }
+
+    function IsNewMove(tid) {
+        current_data[tid] = NewData(tid);
+        Tick(tid, current_data[tid]);
+    }
+
+    function ContinueMove(tid) {
+        local data = current_data[tid];
+        data.motion = teams[tid].current.motion;
+        // Keep: frame_count, pip_colors, cancels, armor, metadata
+        // Reset phase state for new move
+        data.had_active = false;
+        data.frames = [[0],[0],[0]];
+        actives[tid] = false;
+        Tick(tid, data);
+    }
+
+    function TickStun(tid, data) {
+        local current = teams[tid].current;
+        data.frame_count++;
+        data.flag_state = current.flagState;
+        data.flag_attack = current.flagAttack;
+        data.flag_states.append(current.flagState);
+        if(::setting.frame_data.GetMetadata(current)[0])data.metadata = ::setting.frame_data.GetMetadata(current);
+        // Yellow = hitstun/blockstun
+        data.pip_colors.append([0.85, 0.8, 0.1]);
+        data.stun_count++;
+    }
+
+    function NewData(tid) {
+        local current = teams[tid].current;
+        return {
+            motion = current.motion
+            take = current.keyTake
+            frame_count = 0
+            frames = [[0],[0],[0]]
+            pip_colors = []
+            had_active = false
+            cancels = []
+            armor = []
+            metadata = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+            flag_state = 0
+            flag_attack = 0
+            flag_states = []
+            stun_count = 0
+            timeline_offset = 0  // pip offset for time alignment
+        };
+    }
+
+    function ClearAll() {
+        foreach(part in parts)part.Clear();
+    }
+
+    function PreFrame() {
+        return true;
+    }
+
+    function Update() {
+        local cfg = ::plugin.cfg.frame_bar;
+        if (!::battle.team) return;
+
+        // Initialize team references
+        for (local tid = 0; tid < 2; tid++) {
+            if (!teams[tid] && "current" in ::battle.team[tid]) {
+                teams[tid] = ::battle.team[tid];
+            }
+        }
+
+        // Save frame_counts BEFORE processing this frame (for timeline alignment)
+        local saved_fc = [0, 0];
+        for (local tid = 0; tid < 2; tid++) {
+            if (current_data[tid]) saved_fc[tid] = current_data[tid].frame_count;
+        }
+
+        // Process each team
+        for (local tid = 0; tid < 2; tid++) {
+            if (!teams[tid]) continue;
+            local current = teams[tid].current;
+
+            if (!current_data[tid]) {
+                current_data[tid] = NewData(tid);
+            }
+
+            local data = current_data[tid];
+
+            // Detect stun: multiple indicators
+            local in_stun = false;
+            // Hitstun: recover > 0 (set by SetRecoverFrame)
+            try { if (current.recover > 0) in_stun = true; } catch(e) {}
+            // Blockstun: guard motions 100-103 (just), 110-113 (barrier), 120-123 (normal)
+            if (current.motion >= 100 && current.motion <= 103) in_stun = true;
+            if (current.motion >= 110 && current.motion <= 113) in_stun = true;
+            if (current.motion >= 120 && current.motion <= 123) in_stun = true;
+            // Also check flagState block bit
+            if (current.flagState & 0x800) in_stun = true;
+            // Combo indicators as fallback
+            try { if (teams[tid].combo_count > 0) in_stun = true; } catch(e) {}
+            try { if (teams[tid].combo_stun > 0) in_stun = true; } catch(e) {}
+
+            // Fresh stun start after a gap -> reset data with timeline offset
+            if (in_stun && !tracked_last_frame[tid]) {
+                current_data[tid] = NewData(tid);
+                data = current_data[tid];
+                // Align: offset = the OTHER player's frame_count at this moment
+                data.timeline_offset = saved_fc[1 - tid];
+            }
+
+            if (cfg.data.enabled) {
+                // Show hitStop frames (don't skip them) -- only skip super freeze
+                if (!teams[tid].time_stop_count) {
+                    if (in_stun) {
+                        TickStun(tid, data);
+                        tracked_last_frame[tid] = true;
+                    } else if (current.motion >= 1000 && ::setting.frame_data.hasData(current)) {
+                        Tick(tid, data);
+                        tracked_last_frame[tid] = true;
+                    } else {
+                        tracked_last_frame[tid] = false;
+                    }
+                }
+            }
+        }
+
+        // Calculate frame advantage
+        local frame_adv = null;
+        local d0 = current_data[0];
+        local d1 = current_data[1];
+        if (d0 && d1) {
+            // Find who is attacking and who is stunned
+            local attacker_tid = -1;
+            local defender_tid = -1;
+            if (d1.stun_count > 0 && d0.frame_count > 0 && d0.frame_count > d1.timeline_offset) {
+                attacker_tid = 0; defender_tid = 1;
+            } else if (d0.stun_count > 0 && d1.frame_count > 0 && d1.frame_count > d0.timeline_offset) {
+                attacker_tid = 1; defender_tid = 0;
+            }
+            if (attacker_tid >= 0) {
+                local atk = current_data[attacker_tid];
+                local def = current_data[defender_tid];
+                // attacker's visual end = frame_count
+                // defender's visual end = timeline_offset + stun_count
+                local atk_end = atk.frame_count;
+                local def_end = def.timeline_offset + def.stun_count;
+                frame_adv = def_end - atk_end;
+            }
+        }
+
+        // Render
+        if (cfg.data.enabled) {
+            parts.framebar1.Render(current_data[0], frame_adv);
+            parts.framebar2.Render(current_data[1], frame_adv);
+        } else {
+            ClearAll();
+            current_data = [null, null];
+        }
+        actives = [false, false];
+    }
+
+    function Enabled(param) {
+        local enabled = (param.game_mode == 40 || ::replay.GetState() == ::replay.PLAY);
+        if (param.game_mode == 40) {
+            local practicerestart = PracticeRestart;
+            function PracticeRestart() {
+                local bar_task = modifiers.frame_bar.task;
+                if (bar_task) {
+                    bar_task.ClearAll();
+                    bar_task.current_data = [null, null];
+                    bar_task.actives = [false, false];
+                    bar_task.tracked_last_frame = [false, false];
+                }
+                practicerestart();
+            };
+        }
+        return enabled;
+    }
+};

--- a/src/Netcode/embed/plugin/framerate_control.nut
+++ b/src/Netcode/embed/plugin/framerate_control.nut
@@ -70,16 +70,14 @@ class modifier extends modifier {
 	cfg = null;
     input = null;
     text = null;
-    mode = null;
-    i = null;
+    mode = 0;
+    i = 0;
 
     constructor() {
         cfg = ::plugin.cfg.framerate_control;
-        text = ::UI.Core.Text("");
+        text = ::UI.Core.Text();
         text.ConnectRenderSlot(::graphics.slot.front,0);
 
-        i = 0;
-        
         input = ::plugin.Input.InputManager({
             keyboard = ::plugin.Input.InputDevice(cfg.data.bind_keyboard)
             controller = ::plugin.Input.InputDevice(cfg.data.bind_controller)
@@ -93,14 +91,18 @@ class modifier extends modifier {
         if(input.b3 == 1)mode = 3;//1/3
         if(input.b4 == 1)mode = 4;//1/4
 
-        i = (i + 1) % mode; 
-        
+        if (mode > 0) {
+            i = (i + 1) % mode;
+        } else {
+            i = 1; // normal speed: always process frame
+        }
+
         local b0 = input.b0;
         if (b0 && (!(b0 % 10) || b0 == 1)) {
             ::sound.PlaySE("sys_ok");
 			i = mode;
-		} 
-		
+		}
+
         text.Set(mode > 1 ? ::format("1/%s",mode+"") : "");
 
         return !!i;

--- a/src/Netcode/embed/plugin/oki_dummy.nut
+++ b/src/Netcode/embed/plugin/oki_dummy.nut
@@ -1,0 +1,607 @@
+// Oki Dummy - training mode wakeup/block reversal for practice P2
+//
+// Architecture:
+//   - player2=0 + guard_mode=1 + ex_guard_mode=1 during barrier window.
+//     Practice_CommonUpdate (player2<3 path) sets autoGuard=true,
+//     autoBaria=1. CalcContactTestGuard sees autoGuard → guard_state=1.
+//     IsFree() is false during jump → Practice_Com_Wait NOT called →
+//     CommonPracticeLoop NOT called → inputs not zeroed.
+//   - forceBariaCount + guardBaria: survive Practice_CommonUpdate.
+//     PlayerGuardAction_Normal (hit time) checks forceBariaCount>0 +
+//     guardBaria → autoBaria=1 → BariaGuard_Init (barrier guard).
+//   - player2=4 + device hijack for action injection (before barrier).
+//   - Detection: transition from IsDamage → fully stand (motion<=1).
+//   - P button (btn==4): temporarily overrides recover_mode so the game's
+//     Practice_CommonUpdate sets input.b3=1 every frame during IsDamage()>=2.
+//     This gives the same seamless timing as the built-in "front(tag)"/
+//     "back(tag)" tech options — zero vulnerability gap.
+//   - Action configured via practice menu page "Oki Dummy":
+//     ::config.practice.oki_dir (1-9) + oki_btn (0-7: A,B,C,D,P,AB,BC,CP; 8=None)
+
+config = {
+    enabled = true
+    delay_frames = 0     // 0 = earliest possible frame after recovery
+    hold_guard = false   // hold back during delay frames (simulates fuzzy defense)
+};
+
+class modifier extends modifier {
+    _cfg = null;
+    _saved_player2 = -1;
+    _was_paused = false;
+    _was_damage = false;
+    _wakeup_active = false;
+    _delay_remaining = -1;
+    _action_pending = false;
+    _proxy = null;
+    _baria_frames = 0;    // remaining frames of active barrier guard window
+    _saved_guard_mode = -1;
+    _saved_ex_guard_mode = -1;
+    _no_guard_mode = false;  // user's guard_mode=0 → keep player2=0 for disableGuard=-1
+    _post_baria_debug = 0;   // frames of debug output after barrier window ends
+    _saved_recover_mode = -1; // saved recover_mode when P button overrides it
+    _picked_dir = 5;   // randomly selected dir from active slots
+    _picked_btn = 0;   // randomly selected btn from active slots
+    _picked_delay = 0; // per-slot delay (fuzzy guard frames)
+    _frame_tick = 0;   // simple counter for pseudo-random
+    _saved_user_eg = -1; // saved ex_guard_mode for engine translation
+    _idle_p2_changed = false; // player2 temporarily changed for idle guard
+    _once_guard_frames = 0;   // guard_mode=3 (once): post-hit guard window
+    _saved_user_gm = -1;      // saved guard_mode for engine translation
+    _reversal_saved_p2 = -1;  // saved player2 for reversal restore
+    _picked_trigger = 0;      // 0=on hit, 1=on block (per-slot trigger type)
+    _was_guard_motion = false; // blockstun state tracking
+
+    function Enabled(param) {
+        return param.game_mode == 40;
+    }
+
+    function constructor() {
+        _cfg = ::plugin.cfg.oki_dummy.data;
+    }
+
+    function PreFrame() {
+        // Disconnect oki sprites from overlay during gameplay
+        // UpdateMain reconnects them when menu is open
+        if ("_oki_sprites" in ::menu) {
+            foreach (s in ::menu._oki_sprites) {
+                try { s.DisconnectRenderSlot(); } catch(e) {}
+            }
+        }
+
+        if (!_cfg.enabled) return true;
+        if (::battle.state != 8) return true;
+
+        // --- pause-menu handling ---
+        if (::menu.pause_hack) {
+            if (!_was_paused) {
+                // pause_hack is set by practice.Initialize, but battle.UpdateMain
+                // doesn't run during the menu. This block fires on the FIRST frame
+                // AFTER the menu closes. Save the user's new settings — don't
+                // restore old values (that would overwrite menu changes).
+                _saved_player2 = ::config.practice.player2;
+                if (_saved_guard_mode >= 0) {
+                    ::config.practice.guard_mode = _saved_guard_mode;
+                    ::config.practice.ex_guard_mode = _saved_ex_guard_mode;
+                    _saved_guard_mode = -1;
+                }
+                _RestoreRecoverMode();
+                _baria_frames = 0;
+                _no_guard_mode = (::config.practice.guard_mode == 0 && ::config.practice.ex_guard_mode == 0);
+                _once_guard_frames = 0;
+                _action_pending = false;
+                _wakeup_active = false;
+                _reversal_saved_p2 = -1;
+                _was_paused = true;
+            }
+            return true;
+        }
+        if (_was_paused) {
+            _saved_player2 = ::config.practice.player2;
+            _no_guard_mode = (::config.practice.guard_mode == 0 && ::config.practice.ex_guard_mode == 0);
+            _once_guard_frames = 0;
+            _action_pending = false;
+            _wakeup_active = false;
+            _reversal_saved_p2 = -1;
+            _was_paused = false;
+        }
+
+        local team1 = ::battle.team[1];
+        if (!team1 || !team1.current) return true;
+        local p2 = team1.current;
+
+        // --- device hijack ---
+        if (p2.command && (!_proxy || p2.command.device != _proxy)) {
+            _proxy = {
+                x = 0, y = 0,
+                b0 = 0, b1 = 0, b2 = 0, b3 = 0, b4 = 0, b5 = 0,
+                b0r = 0, b1r = 0, b2r = 0, b3r = 0, b4r = 0, b5r = 0
+            };
+            try { p2.command.device = _proxy; ::print("[oki] device hijacked\n"); }
+            catch (e) { _proxy = null; ::print("[oki] hijack FAILED: " + e + "\n"); }
+        }
+
+        // --- first-run: init config defaults ---
+        if (_saved_player2 < 0) {
+            _saved_player2 = ::config.practice.player2;
+            _no_guard_mode = (::config.practice.guard_mode == 0 && ::config.practice.ex_guard_mode == 0);
+        }
+        // First-run: init slot configs + migrate legacy oki_dir/oki_btn
+        if (!("oki_slot" in ::config.practice)) {
+            ::print("[oki] config init: creating defaults\n");
+            ::config.practice.oki_slot <- 0;
+            if ("oki_dir" in ::config.practice) {
+                ::config.practice.oki_s0_dir <- ::config.practice.oki_dir;
+                ::config.practice.oki_s0_btn <- ::config.practice.oki_btn;
+            } else {
+                ::config.practice.oki_s0_dir <- 5;
+                ::config.practice.oki_s0_btn <- 0;
+            }
+            for (local s = 1; s < 5; s++) {
+                ::config.practice["oki_s" + s + "_dir"] <- 5;
+                ::config.practice["oki_s" + s + "_btn"] <- 8;
+            }
+        }
+        // Migrate: ensure weight/delay/trigger exist for all slots
+        for (local s = 0; s < 5; s++) {
+            local wk = "oki_s" + s + "_weight";
+            if (!(wk in ::config.practice)) ::config.practice[wk] <- 5;
+            local dk = "oki_s" + s + "_delay";
+            if (!(dk in ::config.practice)) ::config.practice[dk] <- 0;
+            local tk = "oki_s" + s + "_trigger";
+            if (!(tk in ::config.practice)) ::config.practice[tk] <- 0;
+        }
+
+        // --- P button recover_mode override ---
+        // The game's Practice_CommonUpdate (practice_update.nut) directly sets
+        // this.input.b3=1 and this.input.x=±3 every frame while IsDamage()>=2,
+        // AFTER input processing and CommonPracticeLoop, BEFORE stateLabel.
+        // This gives seamless swap wake-up with zero vulnerability gap.
+        // We temporarily override recover_mode to leverage this mechanism.
+        local btn = _picked_btn;
+        if (btn == 4) {
+            // Map oki_dir to recover_mode: forward→4, backward→5, neutral→5
+            // After _DirToXY + direction conversion: forward = x>0, back = x<0
+            local dir = _picked_dir;
+            local d = _DirToXY(dir);
+            // numpad 6 = forward: d.x=6 before conversion, we check the numpad directly
+            local desired_rm = (dir == 6 || dir == 3 || dir == 9) ? 4 : 5;
+
+            if (_saved_recover_mode < 0) {
+                _saved_recover_mode = ::config.practice.recover_mode;
+            }
+            ::config.practice.recover_mode = desired_rm;
+        } else {
+            _RestoreRecoverMode();
+        }
+
+        // --- calculate guard_active (shared by idle + delay sections) ---
+        // guard_mode: 0=off, 1=all, 2=random, 3=once
+        // All(1) & Random(2): always translate player2 for engine autoGuard.
+        // Once(3): only during post-hit guard window (_once_guard_frames).
+        _saved_user_gm = ::config.practice.guard_mode;
+        local gm = ::config.practice.guard_mode;
+        local guard_active = (gm >= 1 && gm <= 2);
+        if (gm == 3 && _once_guard_frames > 0) {
+            guard_active = true;
+            _once_guard_frames--;
+        }
+
+        // --- maintain guard window (after D actions) ---
+        // Engine mapping: autoBaria=1 → always BariaGuard_Init.
+        // forceBariaCount>=10 → enhanced barrier guard (JustGuardBaria visual = 精防).
+        // ex_guard_mode=2 in Practice_CommonUpdate → autoBaria=2 (random 50%), useless.
+        // So we translate: user_eg 0→autoBaria 0, 1→autoBaria 1, 2→autoBaria 1+forceBariaCount.
+        if (_baria_frames > 0) {
+            ::config.practice.player2 = 0;
+            ::config.practice.guard_mode = 1;
+            local eg = _saved_ex_guard_mode;
+            _ApplyGuardType(p2, eg);
+            _baria_frames--;
+        } else if (!_action_pending) {
+            // Barrier window just ended: restore guard config and player2 ONCE
+            if (_saved_guard_mode >= 0) {
+                ::print("[oki] RESTORE guard_mode=" + _saved_guard_mode
+                    + " ex_guard=" + _saved_ex_guard_mode + "\n");
+                _post_baria_debug = 30;
+                ::config.practice.guard_mode = _saved_guard_mode;
+                ::config.practice.ex_guard_mode = _saved_ex_guard_mode;
+                _saved_guard_mode = -1;
+                if (_no_guard_mode) {
+                    ::config.practice.player2 = 0;
+                } else {
+                    ::config.practice.player2 = _saved_player2;
+                }
+            }
+            // Idle: track user's current player2 (don't override — menu changes must stick)
+            _saved_player2 = ::config.practice.player2;
+            if (guard_active) {
+                // Practice_CommonUpdate clears autoGuard for player2>=3.
+                // Temporarily set player2=0 so the engine handles autoGuard.
+                // Restored in PostFrame.
+                if (::config.practice.player2 >= 3) {
+                    ::config.practice.player2 = 0;
+                    _idle_p2_changed = true;
+                }
+                _ApplyGuardType(p2, ::config.practice.ex_guard_mode);
+            }
+            if (_proxy) _ZeroProxy(p2);
+        }
+
+        // --- action injection ---
+        if (_action_pending) {
+            if (_proxy && p2.command) {
+                // Save player2 before reversal overrides it (restored in PostFrame)
+                if (_reversal_saved_p2 < 0) {
+                    _reversal_saved_p2 = ::config.practice.player2;
+                }
+                _ZeroProxy(p2);
+
+                if (_delay_remaining > 0) {
+                    // Fuzzy defense during delay frames
+                    // Only guard when Guard is enabled; otherwise just wait
+                    ::config.practice.player2 = 0;
+                    if (guard_active) {
+                        if (_saved_guard_mode < 0) {
+                            _saved_guard_mode = ::config.practice.guard_mode;
+                            _saved_ex_guard_mode = ::config.practice.ex_guard_mode;
+                        }
+                        ::config.practice.guard_mode = 1;
+                        _ApplyGuardType(p2, _saved_ex_guard_mode);
+                    }
+                    _delay_remaining--;
+                } else {
+                    ::config.practice.player2 = 4;
+                    local dir = _picked_dir;
+                    local abtn = _picked_btn;
+                    // P button is handled by recover_mode override above,
+                    // not by post-stand input injection.
+                    if (abtn == 4) {
+                        _action_pending = false;
+                    } else {
+                        ::print("[oki] injecting dir=" + dir + " btn=" + abtn + "\n");
+                        _InjectAction(p2, dir, abtn);
+                        _action_pending = false;
+                    }
+                }
+            }
+        }
+
+        // --- translate ex_guard_mode for Practice_CommonUpdate ---
+        // ex_guard_mode=2 causes Practice_CommonUpdate to set autoBaria=2 (random 50%).
+        // Translate to 1 so it sets autoBaria=1 (guaranteed barrier guard).
+        // _ApplyGuardType already set p2.autoBaria and forceBariaCount directly.
+        _saved_user_eg = ::config.practice.ex_guard_mode;
+        if (_saved_user_eg == 2) {
+            ::config.practice.ex_guard_mode = 1;
+        }
+
+        // Translate guard_mode=3→1 for engine when once window is active.
+        // The engine doesn't reliably handle guard_mode=3; we implement the
+        // once semantics ourselves via _once_guard_frames.
+        if (_saved_user_gm == 3 && guard_active) {
+            ::config.practice.guard_mode = 1;
+        }
+
+        return true;
+    }
+
+    function PostFrame() {
+        if (!_cfg.enabled) return;
+        if (::battle.state != 8) return;
+
+        // Restore user's ex_guard_mode (translated in PreFrame for engine)
+        if (_saved_user_eg >= 0) {
+            ::config.practice.ex_guard_mode = _saved_user_eg;
+            _saved_user_eg = -1;
+        }
+
+        // Restore guard_mode (translated in PreFrame for engine)
+        if (_saved_user_gm >= 0) {
+            ::config.practice.guard_mode = _saved_user_gm;
+            _saved_user_gm = -1;
+        }
+
+        // Restore player2 (translated to 0 in PreFrame for idle guard)
+        if (_idle_p2_changed) {
+            ::config.practice.player2 = _saved_player2;
+            _idle_p2_changed = false;
+        }
+
+        // Restore player2 after reversal action completes (was set to 4 in PreFrame)
+        if (_reversal_saved_p2 >= 0 && !_action_pending) {
+            ::config.practice.player2 = _reversal_saved_p2;
+            _reversal_saved_p2 = -1;
+        }
+
+        local team1 = ::battle.team[1];
+        if (!team1 || !team1.current) return;
+
+        local p2 = team1.current;
+        local is_damage = p2.IsDamage();
+        local is_stand = (p2.motion <= 1);
+        local is_guard_motion = (p2.motion >= 100 && p2.motion <= 123);
+
+        // End barrier window when character returns to idle/free state.
+        // This prevents autoGuard from persisting after landing.
+        if (_baria_frames > 0 && is_stand) {
+            _baria_frames = 0;
+            _post_baria_debug = 30;
+            ::print("[oki] barrier window ended (idle/landed)\n");
+        }
+
+        // Practice_CommonUpdate for player2<3 with guard_mode=0 does NOT
+        // clear autoGuard (switch has no case 0). Explicitly clear it
+        // only when user has disabled guard, to prevent persistent guarding.
+        if (_baria_frames == 0 && !_action_pending && ::config.practice.guard_mode == 0) {
+            p2.autoGuard = false;
+        }
+
+        // Debug: PostFrame guard state during barrier window
+        if (_baria_frames > 0 && _baria_frames <= 45) {
+            ::print("[oki] POST f=" + (_baria_frames+1)
+                + " motion=" + p2.motion
+                + " flag&16=" + (p2.flagState & 16)
+                + " disableGuard=" + p2.disableGuard
+                + " autoGuard=" + p2.autoGuard
+                + " autoBaria=" + p2.autoBaria
+                + " forceBariaCount=" + p2.forceBariaCount
+                + " guardBaria=" + p2.guardBaria
+                + " input.x=" + p2.input.x
+                + " IsGuard=" + p2.IsGuard()
+                + " player2=" + ::config.practice.player2
+                + "\n");
+        }
+
+        // Debug: Post-baria-window frames (after barrier guard ends)
+        if (_post_baria_debug > 0) {
+            ::print("[oki] AFTER f=" + _post_baria_debug
+                + " motion=" + p2.motion
+                + " disableGuard=" + p2.disableGuard
+                + " autoGuard=" + p2.autoGuard
+                + " guard_mode=" + ::config.practice.guard_mode
+                + " ex_guard_mode=" + ::config.practice.ex_guard_mode
+                + " player2=" + ::config.practice.player2
+                + " IsGuard=" + p2.IsGuard()
+                + "\n");
+            _post_baria_debug--;
+        }
+
+        // --- Trigger detection: hit (on-hit) or blockstun (on-block) ---
+        if (!_was_damage && is_damage) {
+            // On-hit: pick from slots with trigger=0
+            _PickRandomSlot(0);
+        }
+        if (!_was_guard_motion && is_guard_motion && !is_damage) {
+            // On-block: pick from slots with trigger=1 (blockstun from attack)
+            _PickRandomSlot(1);
+        }
+
+        // --- Recovery → wakeup ---
+        // Hit recovery: was damaged → now not damaged
+        if (_was_damage && !is_damage) {
+            // P button swap is handled by recover_mode override (PreFrame).
+            // The game's Practice_CommonUpdate + stateLabel handle the swap
+            // seamlessly. No PostFrame action needed for btn==4.
+            local btn = _picked_btn;
+            if (_picked_trigger == 0 && btn != 4 && btn != 8) {
+                _wakeup_active = true;
+            }
+        }
+        // Block recovery: was guarding → now not guarding (and not hit)
+        if (_was_guard_motion && !is_guard_motion && !is_damage) {
+            local btn = _picked_btn;
+            if (_picked_trigger == 1 && btn != 4 && btn != 8) {
+                _wakeup_active = true;
+            }
+        }
+
+        if (_wakeup_active && is_stand) {
+            local dir = _picked_dir;
+            local btn = _picked_btn;
+            ::print("[oki] stand after " + (_picked_trigger == 0 ? "hit" : "block") +
+                "! motion=" + p2.motion + " dir=" + dir + " btn=" + btn + "\n");
+
+            // Clean up stale barrier state from previous wakeup
+            _baria_frames = 0;
+
+            // 5D barrier guard: call after actor update (PostFrame) to
+            // survive CommonCpuLoop's input zeroing. Directional D actions
+            // (4D/6D/7D/8D/9D/1D/2D/3D) are handled via state-function
+            // calls in _CallDAction during PreFrame injection.
+            if (btn == 3 && dir == 5) {
+                try {
+                    p2.Guard_Stance(null);
+                    ::print("[oki] Guard_Stance called directly (5D)\n");
+                } catch (e) {
+                    ::print("[oki] Guard_Stance failed: " + e + "\n");
+                }
+            }
+
+            _delay_remaining = _picked_delay;
+            _action_pending = true;
+            _wakeup_active = false;
+        }
+
+        // Guard mode "once" (guard_mode=3): start 30f guard window when hit or block connects.
+        // Outside this window the dummy doesn't guard. Each new hit/block re-opens the window.
+        if (!_was_damage && is_damage && ::config.practice.guard_mode == 3) {
+            _once_guard_frames = 30;
+            ::print("[oki] guard once: 30f window started (hit)\n");
+        }
+        if (!_was_guard_motion && is_guard_motion && !is_damage && ::config.practice.guard_mode == 3) {
+            _once_guard_frames = 30;
+            ::print("[oki] guard once: 30f window started (block)\n");
+        }
+
+        _was_damage = is_damage;
+        _was_guard_motion = is_guard_motion;
+    }
+
+    function _RestoreRecoverMode() {
+        if (_saved_recover_mode >= 0) {
+            ::config.practice.recover_mode = _saved_recover_mode;
+            _saved_recover_mode = -1;
+        }
+    }
+
+    // Map user's ex_guard_mode to engine autoBaria + forceBariaCount.
+    // Engine: autoBaria=1 → always BariaGuard_Init.
+    //         forceBariaCount>=10 → enhanced barrier (JustGuardBaria visual = 精防).
+    // User: 0=Off (normal), 1=Barrier Guard (盾防), 2=Just Guard (精防).
+    function _ApplyGuardType(p2, user_eg) {
+        if (user_eg == 0) {
+            p2.autoBaria = 0;
+        } else {
+            // Both Barrier (1) and Just (2) use autoBaria=1
+            p2.autoBaria = 1;
+            if (user_eg == 2) {
+                // Just Guard = enhanced barrier guard
+                p2.forceBariaCount = 15;
+                p2.guardBaria = true;
+            }
+        }
+    }
+
+    function _PickRandomSlot(trigger_type = 0) {
+        local active = [];
+        local weights = [];
+        for (local s = 0; s < 5; s++) {
+            local key = "oki_s" + s + "_btn";
+            local tk = "oki_s" + s + "_trigger";
+            local t = (tk in ::config.practice) ? ::config.practice[tk] : 0;
+            if (t != trigger_type) continue;
+            if ((key in ::config.practice) && ::config.practice[key] != 8) {
+                local wk = "oki_s" + s + "_weight";
+                local w = (wk in ::config.practice) ? ::config.practice[wk] : 5;
+                if (w < 1) w = 1;
+                active.append(s);
+                weights.append(w);
+            }
+        }
+        if (active.len() == 0) {
+            _picked_dir = 5;
+            _picked_btn = 8;
+            _picked_delay = 0;
+            _picked_trigger = trigger_type;
+            return;
+        }
+        local total = 0;
+        foreach (w in weights) total += w;
+        _frame_tick = (_frame_tick * 1103515245 + 12345) & 0x7fffffff;
+        local r = _frame_tick % total;
+        local acc = 0;
+        local chosen = active[0];
+        for (local i = 0; i < active.len(); i++) {
+            acc += weights[i];
+            if (r < acc) { chosen = active[i]; break; }
+        }
+        _picked_dir = ::config.practice["oki_s" + chosen + "_dir"];
+        _picked_btn = ::config.practice["oki_s" + chosen + "_btn"];
+        _picked_delay = ::config.practice["oki_s" + chosen + "_delay"];
+        _picked_trigger = trigger_type;
+        local trig_label = trigger_type == 0 ? "hit" : "block";
+        ::print("[oki] picked slot " + chosen + " dir=" + _picked_dir + " btn=" + _picked_btn + " delay=" + _picked_delay + " trig=" + trig_label + " (w=" + weights[active.find(chosen)] + "/" + total + ")\n");
+    }
+
+    function _ZeroProxy(p2 = null) {
+        _proxy.x = 0; _proxy.y = 0;
+        _proxy.b0 = 0; _proxy.b1 = 0; _proxy.b2 = 0;
+        _proxy.b3 = 0; _proxy.b4 = 0; _proxy.b5 = 0;
+        _proxy.b0r = 0; _proxy.b1r = 0; _proxy.b2r = 0;
+        _proxy.b3r = 0; _proxy.b4r = 0; _proxy.b5r = 0;
+        // Clear game-side input/command to prevent button persistence
+        if (p2 && p2.command) {
+            p2.input.b0 = 0; p2.input.b1 = 0; p2.input.b2 = 0;
+            p2.input.b3 = 0; p2.input.b4 = 0; p2.input.b5 = 0;
+            p2.input.x = 0; p2.input.y = 0;
+            p2.command.rsv_k0 = 0; p2.command.rsv_k1 = 0; p2.command.rsv_k2 = 0;
+            p2.command.rsv_k3 = 0; p2.command.rsv_k4 = 0; p2.command.rsv_k5 = 0;
+            p2.command.rsv_x = 0; p2.command.rsv_y = 0;
+        }
+    }
+
+    // Direct state-function injection for D button (b4).
+    // CommonCpuLoop zeros input.b4 irrevocably and command.Update never
+    // restores it, so the only way to trigger D actions is to call the
+    // game's state-transition functions directly.
+    function _CallDAction(p2, d) {
+        p2.input.x = d.x;
+        p2.input.y = d.y;
+
+        if (d.y < 0) {
+            p2.SlideUp_Init(null);
+            ::print("[oki] D-inject: SlideUp x=" + d.x + "\n");
+        } else if (d.y > 0) {
+            p2.SlideFall_Init(null);
+            ::print("[oki] D-inject: SlideFall x=" + d.x + "\n");
+        } else if (d.x > 0) {
+            p2.DashFront_Init(null);
+            ::print("[oki] D-inject: DashFront\n");
+        } else if (d.x < 0) {
+            p2.DashBack_Init(null);
+            ::print("[oki] D-inject: DashBack\n");
+        }
+        // 5D handled in PostFrame via Guard_Stance
+
+        // Start guard window only when Guard is enabled.
+        // Guard=false → just jump/dash, no auto-guard.
+        // Guard=true → guard with type from ex_guard_mode (Off/Just/Barrier).
+        if ((d.x != 0 || d.y != 0) && ::config.practice.guard_mode > 0) {
+            _saved_guard_mode = ::config.practice.guard_mode;
+            _saved_ex_guard_mode = ::config.practice.ex_guard_mode;
+            _baria_frames = 45;
+            ::print("[oki] guard window started (45 frames)\n");
+        }
+    }
+
+    function _DirToXY(dir) {
+        local x = 0, y = 0;
+        if (dir == 1 || dir == 4 || dir == 7) x = -6;
+        if (dir == 3 || dir == 6 || dir == 9) x = 6;
+        if (dir == 7 || dir == 8 || dir == 9) y = -10;
+        if (dir == 1 || dir == 2 || dir == 3) y = 10;
+        return { x = x, y = y };
+    }
+
+    function _InjectAction(p2, dir, btn) {
+        local d = _DirToXY(dir);
+        // Convert numpad direction to character-relative coordinates
+        // P2 faces left (direction=-1), so forward(6) = x<0, back(4) = x>0
+        d.x = d.x * p2.direction;
+
+        p2.input.b0 = 0; p2.input.b1 = 0; p2.input.b2 = 0;
+        p2.input.b3 = 0; p2.input.b4 = 0; p2.input.b5 = 0;
+        p2.input.x = 0; p2.input.y = 0;
+        p2.command.rsv_k0 = 0; p2.command.rsv_k1 = 0; p2.command.rsv_k2 = 0;
+        p2.command.rsv_k3 = 0; p2.command.rsv_k4 = 0; p2.command.rsv_k5 = 0;
+        p2.command.rsv_x = 0; p2.command.rsv_y = 0;
+
+        _proxy.x = d.x;  _proxy.y = d.y;
+        p2.input.x = d.x;  p2.input.y = d.y;
+        p2.command.rsv_x = d.x;  p2.command.rsv_y = d.y;
+
+        if (btn == 0) {
+            _proxy.b0 = 2; p2.input.b0 = 1; p2.command.rsv_k0 = 5;
+        } else if (btn == 1) {
+            _proxy.b1 = 2; p2.input.b1 = 1; p2.command.rsv_k1 = 5;
+        } else if (btn == 2) {
+            _proxy.b2 = 2; p2.input.b2 = 1; p2.command.rsv_k2 = 5;
+        } else if (btn == 3) {
+            _CallDAction(p2, d);
+        } else if (btn == 4) {
+            // P button swap wake-up is handled by recover_mode override.
+            // This path should not be reached (blocked in PreFrame),
+            // but kept as safety fallback.
+            _proxy.b3 = 2; p2.input.b3 = 1; p2.command.rsv_k3 = 7;
+        } else if (btn == 5) {
+            _proxy.b0 = 2; p2.input.b0 = 1; p2.command.rsv_k0 = 5;
+            _proxy.b1 = 2; p2.input.b1 = 1; p2.command.rsv_k1 = 5;
+        } else if (btn == 6) {
+            _proxy.b1 = 2; p2.input.b1 = 1; p2.command.rsv_k1 = 5;
+            _proxy.b2 = 2; p2.input.b2 = 1; p2.command.rsv_k2 = 5;
+        } else if (btn == 7) {
+            _proxy.b2 = 2; p2.input.b2 = 1; p2.command.rsv_k2 = 5;
+            _proxy.b3 = 2; p2.input.b3 = 1; p2.command.rsv_k3 = 7;
+        }
+    }
+};

--- a/src/Netcode/embed/plugin/ping_display.nut
+++ b/src/Netcode/embed/plugin/ping_display.nut
@@ -11,7 +11,7 @@ class modifier extends modifier {
 	text = null;
 	colors = [[1,0,0],[1,1,0],[0,1,0],[0,0,1]];
     constructor() {
-		text = ::UI.Core.Text("");
+		text = ::UI.Core.Text();
 		text.ConnectRenderSlot(::graphics.slot.status,1);
 	}
 

--- a/src/Netcode/embed_manifest.txt
+++ b/src/Netcode/embed_manifest.txt
@@ -57,10 +57,12 @@ embed/plugin/core/input.nut=squiroll/plugin/core/input.nut
 embed/plugin/core/cfg.nut=squiroll/plugin/core/cfg.nut=pluginCFG
 embed/plugin/core/manager.nut=squiroll/plugin/core/manager.nut=plugin
 embed/plugin/frame_data.nut=squiroll/plugin/frame_data.nut
+embed/plugin/frame_bar.nut=squiroll/plugin/frame_bar.nut
 embed/plugin/input_display.nut=squiroll/plugin/input_display.nut
 embed/plugin/ping_display.nut=squiroll/plugin/ping_display.nut
 embed/plugin/framerate_control.nut=squiroll/plugin/framerate_control.nut
 embed/plugin/rollback.nut=squiroll/plugin/rollback.nut
+embed/plugin/oki_dummy.nut=squiroll/plugin/oki_dummy.nut
 
 # UI
 embed/UI/core.nut=squiroll/UI/core.nut=UICore


### PR DESCRIPTION
two practice mode features for training:
### 1. sf6 style frame meter
two player frame data bar with attack phases (startup/active/recovery), stun states (hitstun/blockstun/barrier guard), frame advantage with color coding, cancel/invulnerability overlays, and segment length labels. supports overflow wrapping for >60f moves and replay playback.

### 2. dummy reversal trainer
wakeup(block reversal will be added soon) reversal training dummy with:
- 5 weighted-random reversal slots (direction/action/weight/delay)
- actions: a/b/c/d/p/ab/bc/cp/none with numpad directions
- p-button swap wakeup via recover_mode override
- d-action guard window (45f barrier guard)
- optimized guard modes for all practice settings: off / all / random / once (30f posthit window)
- new guard types for practice mode: normal / barrier / just guard
- native anime rendered menu integration

includes upstream compat fixes. version need beta test.